### PR TITLE
Soporte de m7b5 + armonización de Do mayor

### DIFF
--- a/tools/backing-track/app.js
+++ b/tools/backing-track/app.js
@@ -64,6 +64,7 @@
     { v: 'dom7',  label: 'Dominante 7' },
     { v: 'maj7',  label: 'Mayor 7' },
     { v: 'min7',  label: 'menor 7' },
+    { v: 'm7b5',  label: 'Semidisminuido (m7♭5)' },
   ];
   const ROOTS = (theory && theory.CHROMATIC) ||
     ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];

--- a/tools/backing-track/factory-data.test.js
+++ b/tools/backing-track/factory-data.test.js
@@ -11,7 +11,7 @@
   }
 
   const TIPOS = ['bajo', 'acordes', 'bateria', 'percusion', 'pad', 'lead'];
-  const QUALITIES = ['major', 'minor', 'dom7', 'maj7', 'min7'];
+  const QUALITIES = ['major', 'minor', 'dom7', 'maj7', 'min7', 'm7b5'];
 
   T.describe('factoryPresets — forma y cobertura', () => {
     T.it('cada preset tiene id, nombre, tipo, motor y config', () => {

--- a/tools/backing-track/integration.js
+++ b/tools/backing-track/integration.js
@@ -21,8 +21,8 @@
   // m7b5). Se mapean a la aproximación soportada más cercana.
   const QUALITY_MAP = {
     major: 'major', minor: 'minor',
-    maj7: 'maj7', min7: 'min7', dom7: 'dom7',
-    dim7: 'min7', m7b5: 'min7',
+    maj7: 'maj7', min7: 'min7', dom7: 'dom7', m7b5: 'm7b5',
+    dim7: 'm7b5',   // dim7 puro no está soportado: m7b5 es lo más cercano
   };
   const VALID_ROOT = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
 

--- a/tools/backing-track/integration.test.js
+++ b/tools/backing-track/integration.test.js
@@ -18,13 +18,13 @@
       T.assertEq(out[0].quality, 'maj7');
       T.assertEq(out[2].quality, 'dom7');
     });
-    T.it('mapea dim7 y m7b5 a la aproximación soportada (min7)', () => {
+    T.it('m7b5 pasa directo; dim7 (no soportado) se aproxima a m7b5', () => {
       const out = tr([
         { root: 'C', quality: 'dim7', bars: 1 },
         { root: 'E', quality: 'm7b5', bars: 1 },
       ]);
-      T.assertEq(out[0].quality, 'min7');
-      T.assertEq(out[1].quality, 'min7');
+      T.assertEq(out[0].quality, 'm7b5');
+      T.assertEq(out[1].quality, 'm7b5');
     });
     T.it('acota los compases al rango 1..8', () => {
       const out = tr([

--- a/tools/backing-track/progressions.js
+++ b/tools/backing-track/progressions.js
@@ -53,6 +53,19 @@
       ],
     },
     {
+      id: 'armonizacionCmaj', nombre: 'Armonización de Do mayor', genero: 'estudio',
+      tempo: 100,
+      chords: [
+        { root: 'C', quality: 'maj7', bars: 1 },
+        { root: 'D', quality: 'min7', bars: 1 },
+        { root: 'E', quality: 'min7', bars: 1 },
+        { root: 'F', quality: 'maj7', bars: 1 },
+        { root: 'G', quality: 'dom7', bars: 1 },
+        { root: 'A', quality: 'min7', bars: 1 },
+        { root: 'B', quality: 'm7b5', bars: 1 },
+      ],
+    },
+    {
       id: 'metalEmin', nombre: 'Metal en Em', genero: 'metal',
       tempo: 140,
       chords: [

--- a/tools/backing-track/voicing.test.js
+++ b/tools/backing-track/voicing.test.js
@@ -21,6 +21,11 @@
         voicing.resolveChord({ root: 'C', quality: 'min7' }, { octave: 3 }),
         ['C3', 'D#3', 'G3', 'A#3']);
     });
+    T.it('Bm7b5 — semidisminuido (1 b3 b5 b7)', () => {
+      T.assertArrayEq(
+        voicing.resolveChord({ root: 'B', quality: 'm7b5' }, { octave: 3 }),
+        ['B3', 'D4', 'F4', 'A4']);
+    });
     T.it('Gmaj7 cruza el límite de octava correctamente', () => {
       T.assertArrayEq(
         voicing.resolveChord({ root: 'G', quality: 'maj7' }, { octave: 3 }),

--- a/tools/shared/theory.js
+++ b/tools/shared/theory.js
@@ -49,6 +49,7 @@
     dom7:  [0, 4, 7, 10],
     maj7:  [0, 4, 7, 11],
     min7:  [0, 3, 7, 10],
+    m7b5:  [0, 3, 6, 10],
   };
 
   const CHORD_INTERVALS = {
@@ -57,6 +58,7 @@
     dom7:  ['1', '3', '5', 'b7'],
     maj7:  ['1', '3', '5', '7'],
     min7:  ['1', 'b3', '5', 'b7'],
+    m7b5:  ['1', 'b3', 'b5', 'b7'],
   };
 
   function buildChord(root, quality) {
@@ -119,10 +121,12 @@
 
   const QUALITY_LABELS = {
     major: 'Mayor', minor: 'Menor', dom7: '7', maj7: 'maj7', min7: 'm7',
+    m7b5: 'm7b5',
   };
 
   const QUALITY_SUFFIX = {
     major: '', minor: 'm', dom7: '7', maj7: 'maj7', min7: 'm7',
+    m7b5: 'm7b5',
   };
 
   function chordName(root, quality) {
@@ -144,6 +148,7 @@
     dom7:  'mixolydian',
     maj7:  'major',
     min7:  'minor',
+    m7b5:  'minor',
   };
 
   // Picks the scale to overlay over a chord. When opts.scaleAuto is true

--- a/tools/shared/theory.test.js
+++ b/tools/shared/theory.test.js
@@ -75,6 +75,11 @@
       T.assertArrayEq(c.notes, ['E','G','B','D']);
       T.assertArrayEq(c.intervals, ['1','b3','5','b7']);
     });
+    T.it('B m7b5 — notas (semidisminuido)', () => {
+      const c = buildChord('B', 'm7b5');
+      T.assertArrayEq(c.notes, ['B','D','F','A']);
+      T.assertArrayEq(c.intervals, ['1','b3','b5','b7']);
+    });
     T.it('root / quality preservados', () => {
       const c = buildChord('A', 'minor');
       T.assertEq(c.root, 'A');


### PR DESCRIPTION
## Qué

- Agrega la calidad de acorde **m7♭5** (semidisminuido) a `tools/shared/theory.js`. Cambio aditivo: no rompe nada y, de paso, hace que la opción "m7b5" del menú del Intervalic Atlas — que ya existía pero caía a mayor — suene correctamente.
- Nueva progresión de fábrica en el módulo de backing tracks: **Armonización de Do mayor** (`Cmaj7 – Dm7 – Em7 – Fmaj7 – G7 – Am7 – Bm7♭5`).
- m7♭5 disponible en el constructor de acordes del módulo.
- `integration.js`: m7♭5 pasa directo desde el Atlas; dim7 (no soportado) se aproxima a m7♭5.

## Tests

99 tests del backing track + 69 de `theory` en verde. `check-no-modules.sh` pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)