### PR TITLE
Figuras rítmicas + instrumentos tradicionales (WebAudioFont)

### DIFF
--- a/tools/backing-track/patterns.js
+++ b/tools/backing-track/patterns.js
@@ -107,6 +107,23 @@
         lane('kick',  [0, 8, 10], 0.9),
         lane('snare', [4, 12], 0.8),
         lane('hat',   [0, 2, 4, 6, 8, 10, 12, 14], 0.55)) },
+
+    // ─── Figuras rítmicas (golpes parejos: elegí cómo suena el voicing) ───
+    // Acordes: redonda / blanca / negra / corchea / semicorchea.
+    { id: 'acordesRedonda', nombre: 'Redonda', tipo: 'chord',
+      steps: 16, lanes: ['main'], hits: mono([0], 0.65) },
+    { id: 'acordesCorcheas', nombre: 'Corcheas', tipo: 'chord',
+      steps: 16, lanes: ['main'], hits: mono([0,2,4,6,8,10,12,14], 0.6) },
+    { id: 'acordesSemicorcheas', nombre: 'Semicorcheas', tipo: 'chord',
+      steps: 16, lanes: ['main'],
+      hits: mono([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15], 0.5) },
+    // Bajo: corchea y semicorchea (redonda/blanca/negra ya existen como
+    // Raíz / Octavas / Negras).
+    { id: 'bajoCorcheas', nombre: 'Corcheas', tipo: 'bass',
+      steps: 16, lanes: ['main'], hits: mono([0,2,4,6,8,10,12,14], 0.8) },
+    { id: 'bajoSemicorcheas', nombre: 'Semicorcheas', tipo: 'bass',
+      steps: 16, lanes: ['main'],
+      hits: mono([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15], 0.72) },
   ];
 
   function byId(id) {

--- a/tools/backing-track/presets.js
+++ b/tools/backing-track/presets.js
@@ -492,6 +492,96 @@
       },
       efectos: [{ tipo: 'reverb', cantidad: 0.3 }],
     },
+
+    // Instrumentos tradicionales vía WebAudioFont (soundfonts GM).
+    {
+      id: 'wafGuitarraNylon', nombre: 'Guitarra nylon', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0240_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0240_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.22 }],
+    },
+    {
+      id: 'wafGuitarraAcustica', nombre: 'Guitarra acústica', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0250_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0250_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.22 }],
+    },
+    {
+      id: 'wafGuitarraElectrica', nombre: 'Guitarra eléctrica', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0270_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0270_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.18 }],
+    },
+    {
+      id: 'wafCuerdas', nombre: 'Cuerdas (ensemble)', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0480_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0480_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.4 }],
+    },
+    {
+      id: 'wafViolin', nombre: 'Violín', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0400_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0400_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.35 }],
+    },
+    {
+      id: 'wafCello', nombre: 'Cello', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0420_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0420_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.35 }],
+    },
+    {
+      id: 'wafOrgano', nombre: 'Órgano', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0190_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0190_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.25 }],
+    },
+    {
+      id: 'wafTrompeta', nombre: 'Trompeta', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0560_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0560_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.28 }],
+    },
+    {
+      id: 'wafFlauta', nombre: 'Flauta', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0730_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0730_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.4 }],
+    },
+    {
+      id: 'wafContrabajo', nombre: 'Contrabajo', tipo: 'bajo', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0320_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0320_FluidR3_GM_sf2_file',
+      },
+      efectos: [],
+    },
+    {
+      id: 'wafBajoDedos', nombre: 'Bajo eléctrico (dedos)', tipo: 'bajo', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0330_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0330_FluidR3_GM_sf2_file',
+      },
+      efectos: [],
+    },
     {
       id: 'percBongosReal', nombre: 'Percusión bongós real', tipo: 'percusion', motor: 'sampler',
       config: {

--- a/tools/backing-track/presets.js
+++ b/tools/backing-track/presets.js
@@ -582,6 +582,112 @@
       },
       efectos: [],
     },
+
+    // Cuerdas, vientos y más, vía WebAudioFont.
+    {
+      id: 'wafViola', nombre: 'Viola', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0410_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0410_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.35 }],
+    },
+    {
+      id: 'wafArpa', nombre: 'Arpa', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0460_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0460_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.4 }],
+    },
+    {
+      id: 'wafTrombon', nombre: 'Trombón', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0570_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0570_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.28 }],
+    },
+    {
+      id: 'wafCornoFrances', nombre: 'Corno francés', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0600_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0600_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.32 }],
+    },
+    {
+      id: 'wafSaxoAlto', nombre: 'Saxo alto', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0650_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0650_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.3 }],
+    },
+    {
+      id: 'wafSaxoTenor', nombre: 'Saxo tenor', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0660_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0660_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.3 }],
+    },
+    {
+      id: 'wafClarinete', nombre: 'Clarinete', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0710_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0710_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.32 }],
+    },
+    {
+      id: 'wafOboe', nombre: 'Oboe', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0680_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0680_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.34 }],
+    },
+    {
+      id: 'wafVibrafono', nombre: 'Vibráfono', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0110_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0110_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.35 }],
+    },
+    {
+      id: 'wafMarimba', nombre: 'Marimba', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0120_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0120_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.28 }],
+    },
+    {
+      id: 'wafAcordeon', nombre: 'Acordeón', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0210_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0210_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.2 }],
+    },
+    {
+      id: 'wafCoro', nombre: 'Coro', tipo: 'lead', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0520_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0520_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.5 }],
+    },
+    {
+      id: 'wafTuba', nombre: 'Tuba', tipo: 'bajo', motor: 'webaudiofont',
+      config: {
+        url: 'https://surikov.github.io/webaudiofontdata/sound/0580_FluidR3_GM_sf2_file.js',
+        variable: '_tone_0580_FluidR3_GM_sf2_file',
+      },
+      efectos: [{ tipo: 'reverb', cantidad: 0.25 }],
+    },
     {
       id: 'percBongosReal', nombre: 'Percusión bongós real', tipo: 'percusion', motor: 'sampler',
       config: {


### PR DESCRIPTION
## Qué

- **Figuras rítmicas**: patrones de golpes parejos para elegir rápido cómo suena el voicing — acordes en redonda / corcheas / semicorcheas (blancas y negras ya estaban) y bajo en corcheas / semicorcheas. Se eligen del dropdown de patrón de la pista.
- **Instrumentos tradicionales vía WebAudioFont** (grupo "Reales (internet)"):
  - Cuerdas: guitarra nylon/acústica/eléctrica, violín, viola, cello, contrabajo, cuerdas ensemble, arpa.
  - Vientos: trompeta, trombón, tuba, corno francés, saxo alto y tenor, clarinete, oboe, flauta.
  - Otros: órgano, acordeón, vibráfono, marimba, coro, bajo eléctrico de dedos.

## Tests

99 tests en verde. `check-no-modules.sh` pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)