### PR TITLE
Fix: arquitectura de voces de WebAudioFont (notas que se acumulaban)

### DIFF
--- a/tools/backing-track/app.js
+++ b/tools/backing-track/app.js
@@ -47,6 +47,7 @@
   const arrangePanel = el('arrange-panel');
   const subdivSelect = el('subdiv-select');
   const beatMeter = el('beat-meter');
+  const diagVoices = el('diag-voices');
 
   const TIPO_LABEL = {
     bajo: 'Bajo', acordes: 'Acordes', bateria: 'Batería',
@@ -1070,6 +1071,16 @@
 
   engine.onChordChange(highlightChord);
   engine.onTick(updateBarIndicator);
+  // Diagnóstico: muestra cuántas voces suenan y el máximo de la
+  // sesión. Si el máximo trepa sin parar loop tras loop, hay
+  // acumulación; si se estabiliza, está sano.
+  let voiceMax = 0;
+  engine.onTick(function (tick) {
+    if (!tick) { diagVoices.textContent = 'Voces activas: —'; voiceMax = 0; return; }
+    const n = engine.getActiveVoices();
+    if (n > voiceMax) voiceMax = n;
+    diagVoices.textContent = 'Voces activas: ' + n + ' · máx ' + voiceMax;
+  });
   // Autoguardado de la sesión: debounced, para no escribir en
   // localStorage en cada tick de un slider (eso traba el audio).
   let saveTimer = null;

--- a/tools/backing-track/engine.js
+++ b/tools/backing-track/engine.js
@@ -262,8 +262,9 @@
       if (ev.type === 'hit') {
         rt.instrument.triggerHit(ev.lane, time, ev.velocity);
       } else {
-        rt.instrument.triggerNote(
-          ev.notes, ev.durationSteps + '*16n', time, ev.velocity);
+        // Duración en segundos (la calcula el scheduler) — sin texto
+        // musical: evita ambigüedad de parseo en synth y WebAudioFont.
+        rt.instrument.triggerNote(ev.notes, ev.duration, time, ev.velocity);
       }
     }
 

--- a/tools/backing-track/engine.js
+++ b/tools/backing-track/engine.js
@@ -566,6 +566,19 @@
     function isPlaying() { return playing; }
     function getActiveChordIndex() { return activeChordIndex; }
 
+    // getActiveVoices — diagnóstico: total de voces sonando ahora mismo
+    // en todos los instrumentos. Si crece sin parar, hay acumulación.
+    function getActiveVoices() {
+      let n = 0;
+      Object.keys(runtime).forEach(function (id) {
+        const rt = runtime[id];
+        if (rt && rt.instrument && rt.instrument.voiceCount) {
+          n += rt.instrument.voiceCount() || 0;
+        }
+      });
+      return n;
+    }
+
     // ─── Persistencia (usada por storage.js, #60) ───
     function snapshot() {
       return {
@@ -626,7 +639,7 @@
       setSubdivision, getSubdivision,
       setFocusChord,
       setMode, getMode,
-      play, stop, isPlaying, getActiveChordIndex,
+      play, stop, isPlaying, getActiveChordIndex, getActiveVoices,
       snapshot, restore, dispose,
       onChordChange: function (fn) { on('chord', fn); },
       onStateChange: function (fn) { on('state', fn); },

--- a/tools/backing-track/index.html
+++ b/tools/backing-track/index.html
@@ -44,6 +44,7 @@
     </div>
 
     <div id="status" class="status">Detenido</div>
+    <div id="diag-voices" class="diag">Voces activas: —</div>
 
     <div class="section-label">Compás</div>
     <div class="bar-indicator">

--- a/tools/backing-track/instruments.js
+++ b/tools/backing-track/instruments.js
@@ -258,17 +258,6 @@
 
   // ─── WebAudioFont (instrumentos GM reales por CDN) ───
 
-  let _wafPlayer = null;
-  function wafPlayer() {
-    if (!_wafPlayer) {
-      if (typeof W.WebAudioFontPlayer === 'undefined') {
-        throw new Error('WebAudioFontPlayer no está cargado (vendor/)');
-      }
-      _wafPlayer = new W.WebAudioFontPlayer();
-    }
-    return _wafPlayer;
-  }
-
   const NOTE_INDEX = {
     'C': 0, 'C#': 1, 'D': 2, 'D#': 3, 'E': 4, 'F': 5,
     'F#': 6, 'G': 7, 'G#': 8, 'A': 9, 'A#': 10, 'B': 11,
@@ -281,12 +270,22 @@
   }
 
   // Construye un instrumento WebAudioFont: carga su soundfont GM desde
-  // un CDN libre y lo reproduce con queueWaveTable. El soundfont queda
-  // listo unos instantes después de cargar (igual que un Sampler).
+  // un CDN libre y lo reproduce con queueWaveTable.
+  //
+  // Cada instrumento tiene su PROPIO player (no uno compartido): así
+  // sus voces se pueden cortar de forma aislada y, al hacer dispose,
+  // el player y su pool de envolventes se liberan con él (un player
+  // global acumulaba envolventes para siempre).
+  //
+  // Además se lleva registro de las voces activas para poder cortarlas
+  // explícitamente — no alcanza con cancelQueue.
   function createWebAudioFont(preset) {
     const T = Tone();
     const rawCtx = T.getContext().rawContext;
-    const player = wafPlayer();
+    if (typeof W.WebAudioFontPlayer === 'undefined') {
+      throw new Error('WebAudioFontPlayer no está cargado (vendor/)');
+    }
+    const player = new W.WebAudioFontPlayer();
     const cfg = preset.config || {};
 
     const inputBus = new T.Gain();
@@ -295,6 +294,7 @@
     inputBus.chain.apply(inputBus, effects.concat([outputGain]));
 
     let presetData = null;   // objeto del soundfont, una vez decodificado
+    let voices = [];         // envolventes activas (devueltas por queueWaveTable)
 
     if (cfg.url && cfg.variable) {
       try {
@@ -308,6 +308,28 @@
       }
     }
 
+    // Corta de forma definitiva todas las voces activas: detiene el
+    // buffer source y baja la ganancia a cero. cancelQueue por sí solo
+    // no garantiza que las notas dejen de sonar.
+    function stopAllVoices() {
+      voices.forEach(function (env) {
+        if (!env) return;
+        try {
+          if (env.audioBufferSourceNode) {
+            env.audioBufferSourceNode.stop(0);
+            env.audioBufferSourceNode.disconnect();
+          }
+        } catch (e) {}
+        try {
+          if (env.gain) {
+            env.gain.cancelScheduledValues(0);
+            env.gain.setValueAtTime(0.000001, rawCtx.currentTime);
+          }
+        } catch (e) {}
+      });
+      voices = [];
+    }
+
     return {
       kind: 'melodic',
       output: outputGain,
@@ -315,19 +337,28 @@
         if (!presetData || !notes || !notes.length) return;
         let durSec = 0.5;
         try { durSec = T.Time(duration).toSeconds(); } catch (e) {}
+        if (!(durSec > 0)) durSec = 0.5;   // nunca duración inválida
         const vol = Number.isFinite(velocity) ? velocity : 0.8;
+        // Descartar del registro las voces que ya terminaron.
+        const now = rawCtx.currentTime;
+        voices = voices.filter(function (env) {
+          return env && (env.when + env.duration + 0.1 > now);
+        });
         notes.forEach(function (n) {
-          player.queueWaveTable(rawCtx, inputBus.input, presetData,
-            time, noteToMidi(n), durSec, vol);
+          const env = player.queueWaveTable(rawCtx, inputBus.input,
+            presetData, time, noteToMidi(n), durSec, vol);
+          if (env) voices.push(env);
         });
       },
       triggerHit: function () { /* no aplica */ },
       setConfig: function () { /* WAF no se edita con sliders en v1 */ },
       silence: function () {
         try { player.cancelQueue(rawCtx); } catch (e) {}
+        stopAllVoices();
       },
       dispose: function () {
         try { player.cancelQueue(rawCtx); } catch (e) {}
+        stopAllVoices();
         effects.forEach(fx => { try { fx.dispose(); } catch (e) {} });
         try { inputBus.dispose(); } catch (e) {}
         try { outputGain.dispose(); } catch (e) {}

--- a/tools/backing-track/instruments.js
+++ b/tools/backing-track/instruments.js
@@ -335,9 +335,8 @@
       output: outputGain,
       triggerNote: function (notes, duration, time, velocity) {
         if (!presetData || !notes || !notes.length) return;
-        let durSec = 0.5;
-        try { durSec = T.Time(duration).toSeconds(); } catch (e) {}
-        if (!(durSec > 0)) durSec = 0.5;   // nunca duración inválida
+        let durSec = Number(duration);          // ya viene en segundos
+        if (!(durSec > 0)) durSec = 0.5;         // nunca duración inválida
         const vol = Number.isFinite(velocity) ? velocity : 0.8;
         // Descartar del registro las voces que ya terminaron.
         const now = rawCtx.currentTime;

--- a/tools/backing-track/instruments.js
+++ b/tools/backing-track/instruments.js
@@ -154,6 +154,10 @@
         instrument.triggerAttackRelease(payload, duration, time, velocity);
       },
       triggerHit: function () { /* no aplica a instrumentos melódicos */ },
+      voiceCount: function () {
+        return (typeof instrument.activeVoices === 'number')
+          ? instrument.activeVoices : 0;
+      },
       // silence — corta las notas que estén sonando (release inmediato).
       // Evita que las notas largas (p. ej. del pad) sigan sonando tras
       // un Stop o se apilen al reconstruir el scheduling.
@@ -233,6 +237,7 @@
       output: outputGain,
       triggerNote: function () { /* no aplica a un kit de batería */ },
       setConfig: function () { /* la edición de kit no aplica en v1 */ },
+      voiceCount: function () { return 0; },   // golpes one-shot cortos
       silence: function () { /* los golpes de batería son one-shots cortos */ },
       triggerHit: function (lane, time, velocity) {
         const v = voices[lane];
@@ -308,6 +313,14 @@
       }
     }
 
+    // Descarta del registro las voces que ya terminaron.
+    function pruneVoices() {
+      const now = rawCtx.currentTime;
+      voices = voices.filter(function (env) {
+        return env && (env.when + env.duration + 0.1 > now);
+      });
+    }
+
     // Corta de forma definitiva todas las voces activas: detiene el
     // buffer source y baja la ganancia a cero. cancelQueue por sí solo
     // no garantiza que las notas dejen de sonar.
@@ -338,11 +351,7 @@
         let durSec = Number(duration);          // ya viene en segundos
         if (!(durSec > 0)) durSec = 0.5;         // nunca duración inválida
         const vol = Number.isFinite(velocity) ? velocity : 0.8;
-        // Descartar del registro las voces que ya terminaron.
-        const now = rawCtx.currentTime;
-        voices = voices.filter(function (env) {
-          return env && (env.when + env.duration + 0.1 > now);
-        });
+        pruneVoices();
         notes.forEach(function (n) {
           const env = player.queueWaveTable(rawCtx, inputBus.input,
             presetData, time, noteToMidi(n), durSec, vol);
@@ -351,6 +360,7 @@
       },
       triggerHit: function () { /* no aplica */ },
       setConfig: function () { /* WAF no se edita con sliders en v1 */ },
+      voiceCount: function () { pruneVoices(); return voices.length; },
       silence: function () {
         try { player.cancelQueue(rawCtx); } catch (e) {}
         stopAllVoices();

--- a/tools/backing-track/styles.css
+++ b/tools/backing-track/styles.css
@@ -135,6 +135,16 @@ body {
 .status.playing { color: var(--accent); }
 .status.error   { color: #e74c3c; }
 
+/* Diagnóstico: contador de voces activas */
+.diag {
+  text-align: center;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  margin-top: 4px;
+  min-height: 1.2em;
+}
+
 /* ─── Filas de control (slider + valor) ─── */
 .control-row {
   display: flex;


### PR DESCRIPTION
## Problema

Las notas de los instrumentos WebAudioFont parecían acumularse — la nota anterior no desaparecía al cambiar de acorde.

## Causa / rework

Todos los instrumentos WAF compartían **un solo `WebAudioFontPlayer`**, cuyo pool de envolventes crecía indefinidamente y nunca se liberaba (ni al hacer dispose de un instrumento).

- Cada instrumento WAF tiene ahora **su propio player** — se libera al hacer dispose.
- El instrumento **lleva registro de sus voces activas** y las corta de forma explícita (`stop()` del buffer source + ganancia a cero) en `silence()` y `dispose()` — `cancelQueue` por sí solo no garantizaba el corte.
- `triggerNote` descarta del registro las voces ya terminadas y nunca pasa una duración inválida.

## Tests

`check-no-modules.sh` y los tests headless en verde. El motor WAF es audio: se verifica en navegador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)