### PR TITLE
Grooves de estilo (blues, metal, modal…)

### DIFF
--- a/tools/backing-track/LEEME.md
+++ b/tools/backing-track/LEEME.md
@@ -1,0 +1,27 @@
+# Backing Track — módulo
+
+Herramienta web de backing tracks (acompañamiento para improvisar).
+Funciona abriendo `backing-track/index.html` directamente en el
+navegador (`file://`, sin servidor).
+
+## Estructura
+
+- `backing-track/index.html` — entrada y **markup de toda la UI**
+- `backing-track/styles.css` — **todos los estilos**
+- `backing-track/app.js` — glue de la interfaz (arma el DOM dinámico:
+  pistas, editores, indicadores)
+- `backing-track/engine.js` — motor de audio (Tone.js)
+- resto de `*.js` — lógica de datos/audio
+- `backing-track/vendor/` — librerías (Tone.js, WebAudioFont)
+- `shared/`, `intervallic/` — dependencias del repo que la página usa
+
+## Para mejorar el apartado visual
+
+Los archivos que importan son **`index.html`** (estructura) y
+**`styles.css`** (estética). `app.js` genera DOM dinámico, así que
+también influye en clases/estructura.
+
+Restricciones a respetar:
+- Sin build tooling, sin ES modules: debe seguir funcionando con
+  `file://`. CSS y JS planos.
+- Mantener los `id` de los elementos (el JS los referencia).

--- a/tools/backing-track/app.js
+++ b/tools/backing-track/app.js
@@ -897,6 +897,35 @@
 
     arrangePanel.innerHTML = '';
 
+    // Groove de estilo — aplica patrones + tempo a todas las pistas.
+    const grLabel0 = document.createElement('div');
+    grLabel0.className = 'section-label';
+    grLabel0.textContent = 'Groove de estilo';
+    arrangePanel.appendChild(grLabel0);
+    const grRow = document.createElement('div');
+    grRow.className = 'control-row';
+    const grCap = document.createElement('label');
+    grCap.textContent = 'Aplicar';
+    const grSel = fld('select');
+    const grPlaceholder = document.createElement('option');
+    grPlaceholder.value = '';
+    grPlaceholder.textContent = '(elegir un groove…)';
+    grSel.appendChild(grPlaceholder);
+    (BT.factoryGrooves ? BT.factoryGrooves.GROOVES : []).forEach(g => {
+      const opt = document.createElement('option');
+      opt.value = g.id;
+      opt.textContent = g.nombre;
+      grSel.appendChild(opt);
+    });
+    grSel.addEventListener('change', function () {
+      if (grSel.value) applyGroove(grSel.value);
+      // Es una acción, no un estado: vuelve al placeholder.
+      grSel.value = '';
+    });
+    grRow.appendChild(grCap);
+    grRow.appendChild(grSel);
+    arrangePanel.appendChild(grRow);
+
     // Humanización (intensidad global).
     const humLabel = document.createElement('div');
     humLabel.className = 'section-label';
@@ -960,6 +989,21 @@
   function refreshTracks() {
     renderTracks();
     renderArrange();
+  }
+
+  // Aplica un groove de estilo: pone el patrón que le corresponde a
+  // cada pista y el tempo sugerido, de un solo paso.
+  function applyGroove(grooveId) {
+    const groove = BT.factoryGrooves && BT.factoryGrooves.byId(grooveId);
+    if (!groove) return;
+    engine.getTracks().forEach(track => {
+      const pt = PATTERN_TIPO[track.tipo];
+      const pid = pt && groove.patterns[pt];
+      if (pid) engine.updateTrack(track.id, { patternId: pid });
+    });
+    if (groove.tempo) engine.setTempo(groove.tempo);
+    syncControls();
+    refreshTracks();
   }
 
   // ─── Proyectos y persistencia ───

--- a/tools/backing-track/factory-data.test.js
+++ b/tools/backing-track/factory-data.test.js
@@ -115,6 +115,28 @@
     });
   });
 
+  T.describe('factoryGrooves — forma y referencias', () => {
+    const grooves = BT.factoryGrooves;
+    T.it('cada groove tiene id, nombre y patterns', () => {
+      grooves.GROOVES.forEach(g => {
+        T.assert(!!g.id && !!g.nombre && !!g.patterns,
+          'groove incompleto: ' + JSON.stringify(g.id));
+      });
+    });
+    T.it('todos los patrones que referencia un groove existen', () => {
+      grooves.GROOVES.forEach(g => {
+        Object.keys(g.patterns).forEach(k => {
+          T.assert(patterns.byId(g.patterns[k]) !== null,
+            'patrón inexistente en groove ' + g.id + ': ' + g.patterns[k]);
+        });
+      });
+    });
+    T.it('byId encuentra un groove y devuelve null si no existe', () => {
+      T.assertEq(grooves.byId('bluesShuffle').genero, 'blues');
+      T.assertEq(grooves.byId('noExiste'), null);
+    });
+  });
+
 })(
   (typeof window !== 'undefined' ? window : globalThis).GuitarShared,
   (typeof window !== 'undefined' ? window : globalThis)

--- a/tools/backing-track/grooves.js
+++ b/tools/backing-track/grooves.js
@@ -1,0 +1,71 @@
+// ─────────────────────────────────────────────────────────────
+// Backing Track — grooves de estilo (solo datos)
+//
+// Un groove es un "atajo de estilo": agrupa el patrón rítmico que le
+// corresponde a cada tipo de pista (bajo, acordes, batería, percusión)
+// más un tempo sugerido. Aplicar un groove pone de una vez el feel de
+// blues, metal, modal, etc. en todas las pistas.
+//
+// Las claves de `patterns` son tipos de patrón (bass | chord | drums |
+// perc); los valores son ids de patrones de patterns.js.
+//
+// IIFE + namespace global.
+// ─────────────────────────────────────────────────────────────
+(function (W) {
+  'use strict';
+
+  const GROOVES = [
+    {
+      id: 'bluesShuffle', nombre: 'Blues — shuffle', genero: 'blues', tempo: 92,
+      patterns: { bass: 'bluesBass', chord: 'bluesComp',
+                  drums: 'bluesShuffleDrums', perc: 'percBalada' },
+    },
+    {
+      id: 'bluesLento', nombre: 'Blues — lento', genero: 'blues', tempo: 68,
+      patterns: { bass: 'bajoNegras', chord: 'acordesBlancas',
+                  drums: 'baladaSuave', perc: 'percBalada' },
+    },
+    {
+      id: 'metalGalope', nombre: 'Metal — galope', genero: 'metal', tempo: 160,
+      patterns: { bass: 'metalGalopeBass', chord: 'metalChug',
+                  drums: 'metalDoblePedal' },
+    },
+    {
+      id: 'metalMedio', nombre: 'Metal — medio tiempo', genero: 'metal', tempo: 124,
+      patterns: { bass: 'bajoNegras', chord: 'acordesNegras',
+                  drums: 'rockBasico' },
+    },
+    {
+      id: 'modalVamp', nombre: 'Modal — vamp', genero: 'modal', tempo: 116,
+      patterns: { bass: 'bajoRaiz', chord: 'acordesSostenido',
+                  drums: 'modalGroove', perc: 'percLatina' },
+    },
+    {
+      id: 'rockGroove', nombre: 'Rock', genero: 'rock', tempo: 120,
+      patterns: { bass: 'bajoOctavas', chord: 'acordesNegras',
+                  drums: 'rockBasico' },
+    },
+    {
+      id: 'funkGroove', nombre: 'Funk', genero: 'funk', tempo: 104,
+      patterns: { bass: 'bajoSincopado', chord: 'acordesSincopado',
+                  drums: 'funkSeco', perc: 'percPop' },
+    },
+    {
+      id: 'bossaGroove', nombre: 'Bossa', genero: 'bossa', tempo: 122,
+      patterns: { bass: 'bajoOctavas', chord: 'acordesSincopado',
+                  drums: 'bossa', perc: 'percSamba' },
+    },
+    {
+      id: 'popGroove', nombre: 'Pop', genero: 'pop', tempo: 100,
+      patterns: { bass: 'bajoNegras', chord: 'acordesNegras',
+                  drums: 'popEstandar', perc: 'percPop' },
+    },
+  ];
+
+  function byId(id) {
+    return GROOVES.find(g => g.id === id) || null;
+  }
+
+  W.BackingTrack = W.BackingTrack || {};
+  W.BackingTrack.factoryGrooves = { GROOVES, byId };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tools/backing-track/index.html
+++ b/tools/backing-track/index.html
@@ -167,6 +167,7 @@
   <script src="./presets.js"></script>
   <script src="./patterns.js"></script>
   <script src="./progressions.js"></script>
+  <script src="./grooves.js"></script>
   <script src="./user-library.js"></script>
   <script src="./storage.js"></script>
   <script src="./integration.js"></script>

--- a/tools/backing-track/patterns.js
+++ b/tools/backing-track/patterns.js
@@ -124,6 +124,32 @@
     { id: 'bajoSemicorcheas', nombre: 'Semicorcheas', tipo: 'bass',
       steps: 16, lanes: ['main'],
       hits: mono([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15], 0.72) },
+
+    // ─── Patrones de estilo (usados por los grooves) ───
+    // Blues: feel de shuffle aproximado en la grilla de 16 (cada
+    // pulso = paso 0 y 3, "largo-corto").
+    { id: 'bluesShuffleDrums', nombre: 'Shuffle de blues', tipo: 'drums',
+      steps: 16, lanes: KIT_LANES, hits: [].concat(
+        lane('kick',  [0, 8], 0.9),
+        lane('snare', [4, 12], 0.82),
+        lane('hat',   [0, 3, 4, 7, 8, 11, 12, 15], 0.5)) },
+    { id: 'bluesBass', nombre: 'Bajo de blues', tipo: 'bass',
+      steps: 16, lanes: ['main'], hits: mono([0, 3, 8, 11], 0.85) },
+    { id: 'bluesComp', nombre: 'Comping de blues', tipo: 'chord',
+      steps: 16, lanes: ['main'], hits: mono([0, 6, 8, 14], 0.6) },
+    // Metal: galope (pulso = negra + dos semicorcheas → pasos 0,2,3).
+    { id: 'metalGalopeBass', nombre: 'Galope', tipo: 'bass',
+      steps: 16, lanes: ['main'],
+      hits: mono([0, 2, 3, 4, 6, 7, 8, 10, 11, 12, 14, 15], 0.85) },
+    { id: 'metalChug', nombre: 'Chug (galope)', tipo: 'chord',
+      steps: 16, lanes: ['main'],
+      hits: mono([0, 2, 3, 4, 6, 7, 8, 10, 11, 12, 14, 15], 0.7) },
+    // Modal: groove abierto y relajado.
+    { id: 'modalGroove', nombre: 'Modal abierto', tipo: 'drums',
+      steps: 16, lanes: KIT_LANES, hits: [].concat(
+        lane('kick',  [0, 6, 10], 0.82),
+        lane('snare', [4, 12], 0.7),
+        lane('hat',   [0, 2, 4, 6, 8, 10, 12, 14], 0.45)) },
   ];
 
   function byId(id) {

--- a/tools/backing-track/tests.html
+++ b/tools/backing-track/tests.html
@@ -46,6 +46,7 @@
   <script src="./presets.js"></script>
   <script src="./patterns.js"></script>
   <script src="./progressions.js"></script>
+  <script src="./grooves.js"></script>
   <script src="./factory-data.test.js"></script>
   <script src="./user-library.js"></script>
   <script src="./storage.js"></script>


### PR DESCRIPTION
## Qué

Agrega **grooves de estilo**: un groove agrupa el patrón rítmico que le corresponde a cada tipo de pista (bajo, acordes, batería, percusión) más un tempo sugerido. Aplicarlo pone el feel de un estilo en todas las pistas de un solo paso.

- **9 grooves de fábrica**: Blues shuffle, Blues lento, Metal galope, Metal medio tiempo, Modal vamp, Rock, Funk, Bossa, Pop.
- **Patrones de estilo nuevos**: shuffle de blues (batería con hi-hat swingueado, bajo y comping), galope de metal (bajo y chug de acordes), groove modal abierto.
- **UI**: selector "Groove de estilo" en el modo arreglo — al elegir uno, aplica los patrones a todas las pistas y ajusta el tempo.

## Tests

3 tests nuevos verifican que los patrones referenciados por cada groove existen. 16 tests de datos de fábrica + el resto en verde. `check-no-modules.sh` pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)