### PR TITLE
Atlas: leyenda colapsable (modo solo acorde)

### DIFF
--- a/tools/intervallic.html
+++ b/tools/intervallic.html
@@ -109,6 +109,8 @@
     .legend-toggle.off{opacity:.35;text-decoration:line-through}
     .legend-toggle.is-chord{border-bottom:2px solid var(--gold)}
     .legend-toggle.reset{color:var(--gold);border-color:var(--gold-dim);margin-left:8px}
+    .legend-toggle.expander{color:var(--gold);border-color:var(--gold-dim);font-weight:700;margin-right:2px}
+    .legend-toggle.expander.is-expanded{background:rgba(212,168,71,.14)}
 
     .empty-state{padding:30px 14px;text-align:center;color:var(--text-dim);font-size:12px;line-height:1.6}
     .mode-tabs{display:flex;gap:6px;margin-bottom:10px;align-items:center}

--- a/tools/intervallic/atlas.js
+++ b/tools/intervallic/atlas.js
@@ -72,6 +72,8 @@
     loopRange: null, // [startIdx, endIdx] inclusivo o null
     hiddenIntervals: [], // chord tones ocultados del mástil ej ['5','b5']
     extraIntervals: [],  // intervalos NO-acorde encendidos a mano ej ['b6','2']
+    legendExpanded: false, // false = leyenda colapsada (solo acorde). Los
+                           // extras se recuerdan pero no se pintan hasta expandir.
     metroMuted: false,
   };
 
@@ -84,6 +86,17 @@
       if (o.parentKey && !o.diatonicKey)  o.diatonicKey  = o.parentKey;
       if (o.parentMode && !o.diatonicMode) o.diatonicMode = o.parentMode;
       delete o.parentKey; delete o.parentMode;
+      return o;
+    },
+    // v1 → v2: legendExpanded nace en false (leyenda colapsada). Pero quien ya
+    // tenía notas ajenas encendidas las veía en el mástil; arrancar colapsado
+    // se las haría desaparecer sin aviso. Si el estado guardado trae extras,
+    // arrancamos expandido para preservar lo que el usuario ya veía.
+    (s) => {
+      const o = Object.assign({}, s);
+      if (Array.isArray(o.extraIntervals) && o.extraIntervals.length > 0) {
+        o.legendExpanded = true;
+      }
       return o;
     },
   ];
@@ -154,7 +167,7 @@
         nextChord: nextChord(),
         layers: state.layers,
         hiddenIntervals: state.hiddenIntervals,
-        extraIntervals: state.extraIntervals,
+        extraIntervals: effectiveExtras(state.legendExpanded, state.extraIntervals),
         hiddenCells: activeHiddenCells(),
         filter: state.filter,
         showNoteNames: state.showNoteNames,
@@ -699,21 +712,57 @@
   // pura ayuda visual para ubicar, por ej, la b6 en el mástil.
   const LEGEND_INTERVALS = ['1','b2','2','b3','3','4','b5','5','b6','6','b7','7'];
 
+  // ── Helpers puros de la leyenda (colapsar / expandir) ──
+  // Colapsada (default): la leyenda muestra solo los tonos del acorde y el
+  // mástil pinta solo el acorde. Expandida: aparecen las 12 posiciones
+  // cromáticas y los intervalos ajenos encendidos (extraIntervals) se pintan.
+  function legendIntervalsToShow(expanded, chordIntervals) {
+    if (expanded) return LEGEND_INTERVALS.slice();
+    const tones = new Set(chordIntervals || []);
+    return LEGEND_INTERVALS.filter(i => tones.has(i));
+  }
+  // Extras efectivos sobre el mástil. Colapsada → ninguno (se recuerdan en
+  // state.extraIntervals pero no se pintan); expandida → los encendidos.
+  function effectiveExtras(expanded, extraIntervals) {
+    return expanded ? (extraIntervals || []).slice() : [];
+  }
+
   function drawLegend() {
     const lg = $('atlas-legend');
     if (!lg) return;
     lg.innerHTML = '';
     const c = activeChord();
-    const chordTones = new Set(c ? c.intervals : []);
-    const hidden = new Set(state.hiddenIntervals || []);
-    const extra  = new Set(state.extraIntervals || []);
 
     const hint = document.createElement('span');
     hint.style.cssText = 'color:var(--text-dim);font-size:10px;margin-right:2px';
-    hint.textContent = 'Leyenda — click para mostrar/ocultar:';
     lg.appendChild(hint);
 
-    LEGEND_INTERVALS.forEach(i => {
+    // Sin acorde activo (progresión vacía) no hay intervalos que mostrar.
+    if (!c) {
+      hint.textContent = 'Leyenda — agregá un acorde para ver sus intervalos.';
+      return;
+    }
+    hint.textContent = 'Leyenda — click para mostrar/ocultar:';
+
+    const chordTones = new Set(c.intervals);
+    const hidden = new Set(state.hiddenIntervals || []);
+    const extra  = new Set(state.extraIntervals || []);
+    const expanded = !!state.legendExpanded;
+
+    // Toggle colapsar/expandir de la leyenda. Colapsada lista solo las notas
+    // del acorde; expandida, las 12 posiciones para sumar notas ajenas (6, 2,
+    // b6…) al mástil. No afecta las capas (escala, tensiones, etc.).
+    const expander = document.createElement('button');
+    expander.className = 'legend-toggle expander' + (expanded ? ' is-expanded' : '');
+    expander.textContent = expanded ? '▾ Todas' : '▸ Solo acorde';
+    expander.title = expanded
+      ? 'Mostrando las 12 notas de la leyenda — click para ver solo el acorde'
+      : 'Mostrando solo el acorde — click para sumar las demás (6, 2, b6…)';
+    expander.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    expander.addEventListener('click', toggleLegendExpanded);
+    lg.appendChild(expander);
+
+    legendIntervalsToShow(expanded, c.intervals).forEach(i => {
       const isChord = chordTones.has(i);
       // "on" = visible en el mástil. Nota del acorde: visible salvo que se
       // oculte. Nota ajena: oculta salvo que se encienda a mano.
@@ -730,8 +779,11 @@
 
     // Reset: vuelve al acorde puro (sin ocultos ni extras encendidos).
     // También limpia las posiciones ocultas a mano del acorde activo.
+    // Usa los extras EFECTIVOS: en modo colapsado los extras recordados no se
+    // pintan, así que no deben hacer aparecer un Reset sin nada visible.
+    const effExtras = effectiveExtras(expanded, state.extraIntervals);
     const hasHiddenCells = activeHiddenCells().length > 0;
-    if (hidden.size > 0 || extra.size > 0 || hasHiddenCells) {
+    if (hidden.size > 0 || effExtras.length > 0 || hasHiddenCells) {
       const reset = document.createElement('button');
       reset.className = 'legend-toggle reset';
       reset.textContent = 'Reset';
@@ -761,6 +813,14 @@
       extra.has(interval) ? extra.delete(interval) : extra.add(interval);
       state.extraIntervals = Array.from(extra);
     }
+    saveState(); render();
+  }
+
+  // Colapsa/expande la leyenda. Colapsada: solo el acorde (los extras se
+  // recuerdan en state.extraIntervals pero no se pintan en el mástil).
+  // Expandida: las 12 posiciones + los extras encendidos.
+  function toggleLegendExpanded() {
+    state.legendExpanded = !state.legendExpanded;
     saveState(); render();
   }
 
@@ -1369,6 +1429,10 @@
     _applyHiddenIntervals: W.FretboardRenderer && W.FretboardRenderer.applyHiddenIntervals,
     _toggleHiddenInterval: toggleHiddenInterval,
     _toggleLegendInterval: toggleLegendInterval,
+    _toggleLegendExpanded: toggleLegendExpanded,
+    _legendIntervalsToShow: legendIntervalsToShow,
+    _effectiveExtras: effectiveExtras,
+    _ATLAS_MIGRATIONS: ATLAS_MIGRATIONS,
     _toggleHiddenCell: toggleHiddenCellAt,
     _handleBoardClick: handleBoardClick,
     _addChordFromBoard: addChordFromBoard,

--- a/tools/intervallic/atlas.test.js
+++ b/tools/intervallic/atlas.test.js
@@ -395,6 +395,51 @@
     });
   });
 
+  T.describe('leyenda — colapsar / expandir (solo acorde)', () => {
+    T.it('legendExpanded arranca en false (colapsada)', () => {
+      A.setProgression([{ root: 'C', quality: 'major', bars: 1 }]);
+      T.assertEq(A.getState().legendExpanded, false);
+    });
+    T.it('colapsada: la leyenda muestra solo los tonos del acorde', () => {
+      T.assertArrayEq(A._legendIntervalsToShow(false, ['1', '3', '5']), ['1', '3', '5']);
+    });
+    T.it('expandida: la leyenda muestra las 12 posiciones cromáticas', () => {
+      const all = A._legendIntervalsToShow(true, ['1', '3', '5']);
+      T.assertEq(all.length, 12);
+      T.assert(all.includes('b2') && all.includes('6') && all.includes('b6'));
+    });
+    T.it('colapsada: los extras NO se pintan en el mástil', () => {
+      T.assertArrayEq(A._effectiveExtras(false, ['6', '2']), []);
+    });
+    T.it('expandida: los extras encendidos sí se pintan', () => {
+      T.assertArrayEq(A._effectiveExtras(true, ['6', '2']), ['6', '2']);
+    });
+    T.it('toggle alterna el flag y los extras se recuerdan al colapsar', () => {
+      A.setProgression([{ root: 'C', quality: 'maj7', bars: 1 }]);
+      A.getState().extraIntervals = [];
+      A.getState().legendExpanded = true;     // partir de expandida
+      A._toggleLegendInterval('6');            // encender la 6 (ajena al acorde)
+      T.assert(A.getState().extraIntervals.includes('6'));
+      A._toggleLegendExpanded();               // colapsar
+      T.assertEq(A.getState().legendExpanded, false);
+      const st = A.getState();
+      // colapsada: la 6 no se pinta en el mástil...
+      T.assertArrayEq(A._effectiveExtras(st.legendExpanded, st.extraIntervals), []);
+      // ...pero sigue recordada en el estado
+      T.assert(st.extraIntervals.includes('6'));
+      A._toggleLegendExpanded();               // re-expandir → reaparece
+      T.assert(A._effectiveExtras(A.getState().legendExpanded, A.getState().extraIntervals).includes('6'));
+    });
+    T.it('migración v1→v2: estado guardado con extras arranca expandido', () => {
+      const migs = A._ATLAS_MIGRATIONS;
+      const v1tov2 = migs[migs.length - 1];
+      T.assertEq(v1tov2({ extraIntervals: ['6'] }).legendExpanded, true);
+      // sin extras (o sin la clave) queda colapsado (false/undefined)
+      T.assert(!v1tov2({ extraIntervals: [] }).legendExpanded);
+      T.assert(!v1tov2({}).legendExpanded);
+    });
+  });
+
   T.describe('hiddenCells — ocultar notas por acorde', () => {
     T.it('toggle afecta solo al acorde activo', () => {
       A.setProgression([


### PR DESCRIPTION
## Qué hace

Agrega un toggle a la leyenda interválica del Interval Atlas para alternar entre **solo acorde** (colapsada) y **todas las notas** (expandida).

- **Colapsada (default):** la leyenda lista solo las notas del acorde y el mástil pinta solo el acorde.
- **Expandida (`▾ Todas`):** aparecen las 12 posiciones cromáticas para encender notas ajenas (6, 2, b6, 9, 11, 13…) sobre el mástil.
- Al colapsar, los extras encendidos **se recuerdan** (no se pierden) y reaparecen al expandir.

Implementado con helpers puros (`legendIntervalsToShow`, `effectiveExtras`) y `render()` gatea los extras según el estado.

## Correcciones de una revisión adversarial multi-agente

- **Migración v1→v2:** estados guardados con extras ya encendidos arrancan expandidos, para no hacérselos desaparecer en silencio al actualizar.
- **Reset** usa los extras *efectivos*: ya no aparece en modo colapsado cuando no hay nada visible que resetear.
- **`aria-expanded`** en el toggle (accesibilidad).
- **Leyenda sin acorde activo** muestra un aviso en vez de botones vacíos/confusos.

## Tests

7 tests nuevos (default colapsada, filtrado de botones, extras gateados, toggle recuerda extras, migración v1→v2). **222 passed · 0 failed.**

## Limitación conocida

El toggle controla las notas de la *leyenda*, no las *capas* (escala, tensiones, próximo acorde). Si una capa está activa, el mástil sigue mostrando esas notas aunque la leyenda diga "Solo acorde". Se puede afinar si molesta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)